### PR TITLE
Improves debug message system

### DIFF
--- a/heisdriver/fsm.c
+++ b/heisdriver/fsm.c
@@ -28,7 +28,7 @@ void fsm_ev_floor_sensor(int floor){		//use current floor, remove floor
 			break;
 
 		case STOP:
-			printf("sensor_signal_stop\n");
+			//printf("sensor_signal_stop\n");
 			motor_dir = DIRN_STOP;
 			elev_set_motor_direction(DIRN_STOP);
 			elev_set_door_open_lamp(1);
@@ -57,7 +57,7 @@ void fsm_ev_floor_sensor(int floor){		//use current floor, remove floor
 
 
 		case EMERGENCY:
-			printf("sensor_signal_emergency\n");
+			//printf("sensor_signal_emergency\n");
 			elev_set_door_open_lamp(1);
 			while(elev_get_stop_signal()){};
 			elev_set_stop_lamp(0);
@@ -92,17 +92,17 @@ void fsm_ev_emergency(){
 	switch (current_state){
 
 		case IDLE:
-			printf("em_signal_idle\n");
+			//printf("em_signal_idle\n");
 		case MOVING:
-			printf("em_signal_moving\n");
+			//printf("em_signal_moving\n");
 		case STOP:
-			printf("em_signal_stop\n");
+			//printf("em_signal_stop\n");
 			current_state = EMERGENCY;
 			break;
 
 		case EMERGENCY:
 			printf("em_signal_em\n");
-			//KAN FLYTTES UDER FSM_EV_EMERGENCY
+			//KAN FLYTTES UNDER FSM_EV_EMERGENCY
 			while(elev_get_stop_signal()){};
 			elev_set_stop_lamp(0);
 			timer_wait(3);
@@ -122,7 +122,7 @@ void fsm_ev_button(elev_button_type_t button, int floor){
 	switch (current_state){
 
 		case IDLE:
-			printf("button_signal_idle\n");
+			//printf("button_signal_idle\n");
 			if(order_get_dir(current_floor)==DIRN_STOP){
 				printf("hjelp\n");
 				current_state = STOP;
@@ -134,13 +134,13 @@ void fsm_ev_button(elev_button_type_t button, int floor){
 			}
 
 		case MOVING:
-			printf("button_signal_mov\n");
+			//printf("button_signal_mov\n");
 			break;
 		case STOP:
-			printf("button_signal_stop\n");
+			//printf("button_signal_stop\n");
 			break;
 		case EMERGENCY:
-			printf("button_signal_em\n");
+			//printf("button_signal_em\n");
 			break;
 
 		}

--- a/heisdriver/fsm.c
+++ b/heisdriver/fsm.c
@@ -146,3 +146,7 @@ void fsm_ev_button(elev_button_type_t button, int floor){
 		}
 
 }
+
+state_t fsm_get_state(){
+	return current_state;
+}

--- a/heisdriver/fsm.c
+++ b/heisdriver/fsm.c
@@ -117,6 +117,7 @@ void fsm_ev_emergency(){
 
 void fsm_ev_button(elev_button_type_t button, int floor){
 	order_update(button, floor);
+	order_print_queue();
 	elev_set_button_lamp(button, floor, 1);
 
 	switch (current_state){

--- a/heisdriver/fsm.h
+++ b/heisdriver/fsm.h
@@ -36,6 +36,4 @@ void fsm_ev_button(elev_button_type_t button, int floor);
 
 state_t fsm_get_state();
 
-
-
 #endif

--- a/heisdriver/fsm.h
+++ b/heisdriver/fsm.h
@@ -34,6 +34,7 @@ void fsm_ev_emergency();
 
 void fsm_ev_button(elev_button_type_t button, int floor);
 
+state_t fsm_get_state();
 
 
 

--- a/heisdriver/main.c
+++ b/heisdriver/main.c
@@ -17,6 +17,8 @@ int main() {
 
     //CODE ABOVE: TESTED
 
+    int cycle_num = 0;
+    state_t prev_state = IDLE;
 
 
 
@@ -41,6 +43,16 @@ int main() {
 
 
         }
+
+        //System messages
+        cycle_num++;
+
+        if(fsm_get_state() != prev_state){
+            printf("Current state: %d, Cycle number: %d",fsm_get_state(),cycle_num);
+
+        }
+
+        prev_state = fsm_get_state();
        
     }
 

--- a/heisdriver/main.c
+++ b/heisdriver/main.c
@@ -46,9 +46,9 @@ int main() {
 
         //System messages
         cycle_num++;
-
+        
         if(fsm_get_state() != prev_state){
-            printf("Current state: %d, Cycle number: %d",fsm_get_state(),cycle_num);
+            printf("Current state: %d, Cycle number: %d \n",fsm_get_state(),cycle_num);
 
         }
 

--- a/heisdriver/main.c
+++ b/heisdriver/main.c
@@ -46,7 +46,7 @@ int main() {
 
         //System messages
         cycle_num++;
-        
+
         if(fsm_get_state() != prev_state){
             printf("Current state: %d, Cycle number: %d \n",fsm_get_state(),cycle_num);
 

--- a/heisdriver/orderSys.c
+++ b/heisdriver/orderSys.c
@@ -25,7 +25,7 @@ void order_update(elev_button_type_t button, int floor) {
 		for (int i = 0; i<4; i++) {
 			if (queue[i] == floor || queue[i] == -1) {
 				queue[i] = floor;
-				printf("queue: %i\n", floor);
+				//printf("queue: %i\n", floor);
 				break;
 			}
 		}
@@ -65,7 +65,7 @@ void order_clear() {
 
 
 elev_motor_direction_t order_get_dir(int floor) {
-	printf("%i floor\n",floor);
+	//printf("%i floor\n",floor);
 
 	if (queue[0]<floor && queue[0]!=-1) {
 		return DIRN_DOWN;
@@ -79,7 +79,7 @@ elev_motor_direction_t order_get_dir(int floor) {
 
 
 	if (active_buttons[floor][1] || active_buttons[floor][0]) {
-		printf("2\n");
+		//printf("2\n");
 
 		return DIRN_STOP;
 
@@ -102,7 +102,7 @@ elev_motor_direction_t order_get_dir(int floor) {
 		return DIRN_DOWN;
 	};
 	
-	printf("end\n");
+	//printf("end\n");
 
 	return DIRN_STOP;
 

--- a/heisdriver/orderSys.c
+++ b/heisdriver/orderSys.c
@@ -1,12 +1,15 @@
 #include "orderSys.h"
 
-/*
-void print_queue(){
+
+void order_print_queue(){
+	printf("Queue: " );
 	for(int f = 0; f<4;f++){
-			printf(queue[f] + "\t" );
+			printf("%d, ",queue[f]);
 	}
+	printf("\n");
 }
 
+/*
 void print_buttons(){
 	for(int f = 0; f<4;f++){
 		for(int b = 0; b<3;b++){
@@ -15,7 +18,6 @@ void print_buttons(){
 		printf("\n");
 	}
 }
-
 */
 
 void order_update(elev_button_type_t button, int floor) {
@@ -110,6 +112,7 @@ elev_motor_direction_t order_get_dir(int floor) {
 
 
 bool order_should_stop(int floor, elev_motor_direction_t dir) {
+	
 	//Check if in queue
 	for (int i = 0; i<4; i++) {
 		if (queue[i] == floor) {

--- a/heisdriver/orderSys.h
+++ b/heisdriver/orderSys.h
@@ -24,4 +24,6 @@ bool orders_none();
 
 void order_clear();
 
+void order_print_queue();
+
 #endif

--- a/heisdriver/orderSys.h
+++ b/heisdriver/orderSys.h
@@ -22,7 +22,6 @@ bool order_should_stop(int floor, elev_motor_direction_t dir);
 
 bool orders_none();
 
-
 void order_clear();
 
 #endif


### PR DESCRIPTION
Debug messages are now printed only when something changes not in every main cycle.

State is printed, and queue is printed. 

## Possible improvements
* We could also print the active_buttons matrix, could be useful. 
* The queue is printed each time a button is updated, and a button is updated as long as it is pressed. This leads to the queue beeing printed each main cycle as long as a button is pressed in. You solve this by either pressing buttons super fast (not the best) or introducing a prev_queue to check for changes and only print when something changes as is done for current state in main.
## Notes
Be wary, there are several poor commit messages in this branch thanks too some too hasty pushing. But the finished code is semi sound.  Also the changes are quite isolated so i do not believe it will lead to future problems.