### PR TITLE
Fix emergency behaviour by introducing new variable real_floor

### DIFF
--- a/heisdriver/fsm.h
+++ b/heisdriver/fsm.h
@@ -25,7 +25,7 @@ typedef enum state_type {
 static state_t current_state;
 static int current_floor;
 static int motor_dir;
-static int previous_floor;
+static double real_floor;
 
 
 bool fsm_init();


### PR DESCRIPTION
The elevator would not go down when a order was placed below it after
an emergency. The variable real_floor is a double that is updated
to reflect where the elevator is between floors e.g 1.5 when between second and first. I think real_floor
should replace current_floor, but that would require quite a bit of
change. The elevator is now working as intended.